### PR TITLE
Fix easy_media.storage_name

### DIFF
--- a/agence-adeliom/easy-media-bundle/2.0/config/packages/easy_media.yaml
+++ b/agence-adeliom/easy-media-bundle/2.0/config/packages/easy_media.yaml
@@ -15,7 +15,7 @@ flysystem:
         directory: '%kernel.project_dir%/var/storage/medias'
 
 easy_media:
-  storage_name: flysystem.adapter.medias.storage
+  storage_name: medias.storage
   media_entity: App\Entity\EasyMedia\Media
   folder_entity: App\Entity\EasyMedia\Folder
 


### PR DESCRIPTION
Awesome bundle!!!

--------------------------------------------------

This commit fixes fresh package installation error for ^2.0.

```
vlad@vb:~/PhpstormProjects/jtmweb$ composer require agence-adeliom/easy-media-bundle
Info from https://repo.packagist.org: #StandWithUkraine
Using version ^2.0 for agence-adeliom/easy-media-bundle
./composer.json has been updated
Running composer update agence-adeliom/easy-media-bundle
Loading composer repositories with package information                                                                                                                                                                                                   Updating dependencies                                 
Lock file operations: 26 installs, 0 updates, 0 removals
  - Locking agence-adeliom/easy-common-bundle (2.0.92)
  - Locking agence-adeliom/easy-media-bundle (2.0.92)
  - Locking composer/ca-bundle (1.3.5)
  - Locking embed/embed (v4.4.7)
  - Locking illuminate/collections (v9.52.6)
  - Locking illuminate/conditionable (v9.52.6)
  - Locking illuminate/contracts (v9.52.6)
  - Locking illuminate/macroable (v9.52.6)
  - Locking illuminate/support (v9.52.6)
  - Locking james-heinrich/getid3 (v1.9.22)
  - Locking league/flysystem-bundle (3.1.0)
  - Locking liip/imagine-bundle (2.10.0)
  - Locking maennchen/zipstream-php (v2.4.0)
  - Locking ml/iri (1.1.4)
  - Locking ml/json-ld (1.2.1)
  - Locking myclabs/php-enum (1.8.4)
  - Locking nesbot/carbon (2.66.0)
  - Locking nyholm/psr7 (1.7.0)
  - Locking oscarotero/html-parser (v0.1.7)
  - Locking php-http/message-factory (1.1.0)
  - Locking psr/http-client (1.0.2)
  - Locking psr/http-factory (1.0.2)
  - Locking psr/http-message (1.1)
  - Locking psr/simple-cache (3.0.0)
  - Locking symfony/psr-http-message-bridge (v2.1.4)
  - Locking voku/portable-ascii (2.0.1)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 0 updates, 0 removals
Package sensio/framework-extra-bundle is abandoned, you should avoid using it. Use Symfony instead.
Generating optimized autoload files
138 packages you are using are looking for funding.
Use the `composer fund` command to find out more!

Symfony operations: 5 recipes (15a1ff214702abbecf9c954ba17b5830)
  - Configuring nyholm/psr7 (>=1.0): From github.com/symfony/recipes:main
  - Configuring liip/imagine-bundle (>=1.8): From github.com/symfony/recipes-contrib:main
  - Configuring league/flysystem-bundle (>=1.0): From github.com/symfony/recipes:main
  - Configuring agence-adeliom/easy-common-bundle (>=1.0): From github.com/agence-adeliom/symfony-recipes:main
  - Configuring agence-adeliom/easy-media-bundle (>=2.0): From github.com/agence-adeliom/symfony-recipes:main
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 255
!!  
!!   // Clearing the cache for the dev environment with debug true                  
!!  
!!  11:49:18 CRITICAL  [php] Uncaught Error: Adeliom\EasyMediaBundle\Service\EasyMediaManager::__construct(): Argument #1 ($filesystem) must be of type League\Flysystem\FilesystemOperator, League\Flysystem\Local\LocalFilesystemAdapter given, called in /home/vlad/PhpstormProjects/jtmweb/var/cache/dev/ContainerPguMWFI/App_KernelDevDebugContainer.php on line 1027 ["exception" => TypeError { …}]
!!  
!!  In EasyMediaManager.php line 30:
!!                                                                                 
!!    Adeliom\EasyMediaBundle\Service\EasyMediaManager::__construct(): Argument #  
!!    1 ($filesystem) must be of type League\Flysystem\FilesystemOperator, League  
!!    \Flysystem\Local\LocalFilesystemAdapter given, called in /home/vlad/Phpstor  
!!    mProjects/jtmweb/var/cache/dev/ContainerPguMWFI/App_KernelDevDebugContainer  
!!    .php on line 1027                                                            
!!                                                                                 
!!  
!!  cache:clear [--no-warmup] [--no-optional-warmers]
!!  
!!  
Script @auto-scripts was called via post-update-cmd

```